### PR TITLE
Fix problem with erl-complete completions for lists module in R1403

### DIFF
--- a/src/otp_doc.erl
+++ b/src/otp_doc.erl
@@ -238,6 +238,8 @@ cache_funcs(M) ->
 
 funcsf(Line,A,M) ->
   case trim_P(string:tokens(A++Line,"<>\"")) of
+    ["a name=",FA,"/a","span class=","bold_code",Sig,"/span"|_] ->  % R14
+      a_line(M,fa(FA),Sig),[];			% R12-
     ["a name=",FA,"span class=","bold_code",Sig,"/span","/a"|_] ->
       a_line(M,fa(FA),Sig),[];			% R12-
     ["A NAME=",FA,"STRONG","CODE",Sig,"/CODE","/STRONG","/A"|_] ->


### PR DESCRIPTION
This patch makes erl-complete return many more possible completions for 'lists:'. Unfortunately docs format was changed and without this patch you get almost empty list of completions.

Few other modules might be affected too. Further patches are needed because completions for 're' still don't work as expected
