### PR TITLE
Robustify erl-ping in case of non-symbol response

### DIFF
--- a/elisp/erl-service.el
+++ b/elisp/erl-service.el
@@ -283,8 +283,9 @@ On an error, Result will be [badrpc Reason]."
     (erl-receive (node)
         ((['rex response]
           (if (or (equal node response)
-                  (equal (symbol-name node)
-                         (concat (symbol-name response) ".local")))
+                  (and (symbolp response)
+                       (equal (symbol-name node)
+                              (concat (symbol-name response) ".local"))))
               (message "Successfully communicated with remote node %S"
                        node)
             (message "Failed to communicate with node %S: %S"


### PR DESCRIPTION
Before the distel module is uploaded i.e. the first `erl-ping` call, the response is not a symbol. This patch makes `erl-ping` more defensive in such cases.
