### PR TITLE
More code cleanup

### DIFF
--- a/elisp/distel-ie.el
+++ b/elisp/distel-ie.el
@@ -139,8 +139,8 @@ call or an expression."
                     (insert "\n")
                     (goto-char my-point)
                     (push-mark (point) t)))
-              (display-message-or-view (format "Result: %s" value)
-                                       "*Evaluation Result*")))
+              (erl-display-message-or-view (format "Result: %s" value)
+                                           "*Evaluation Result*")))
 
            (['msg msg]
             (with-current-buffer buffer

--- a/elisp/edb.el
+++ b/elisp/edb.el
@@ -579,7 +579,7 @@ The *Variables* buffer is killed with the current buffer."
         (message msg)
         (&edb-attach-loop))
        (['show_variable value]
-        (save-excursion (display-message-or-view value "*Variable Value*"))
+        (save-excursion (erl-display-message-or-view value "*Variable Value*"))
         (&edb-attach-loop))
        (other
         (message "Other: %S" other)

--- a/elisp/erl-service.el
+++ b/elisp/erl-service.el
@@ -392,12 +392,12 @@ Available commands:
                            'distel 'process_info_item (list pid item))
              (erl-receive (item pid)
                  ((['rex ['ok string]]
-                   (display-message-or-view string "*pinfo item*"))
+                   (erl-display-message-or-view string "*pinfo item*"))
                   (other
                    (message "Error from erlang side of process_info:\n  %S"
                             other)))))))))
 
-(defun display-message-or-view (msg bufname &optional select)
+(defun erl-display-message-or-view (msg bufname &optional select)
   "Like `display-buffer-or-message', but with `view-buffer-other-window'.
 That is, if a buffer pops up it will be in view mode, and pressing q
 will get rid of it.
@@ -660,7 +660,7 @@ time it spent in subfunctions."
                   (list string))
     (erl-receive ()
         ((['rex ['ok string]]
-          (display-message-or-view string "*Expression Result*"))
+          (erl-display-message-or-view string "*Expression Result*"))
          (['rex ['error reason]]
           (message "Error: %S" reason))
          (other
@@ -1096,7 +1096,7 @@ variables."
   "Show MATCHES from fdoc. Each match is [MOD FUNC ARITY DOC]."
   (if (null matches)
       (message "No matches.")
-    (display-message-or-view
+    (erl-display-message-or-view
      (with-temp-buffer
        (dolist (match matches)
          (mlet [mod func arity doc] match


### PR DESCRIPTION
1. Add prefix erl- to process- functions and variables
   Process is part of emacs so be clear and don't pollute that name
   space.
2. Remove erpc which seems to be a develment helper but isn't
   particularly better than the standard M-: (eval-expression).
3. Remove maybe-select-db-rebuild
