### PR TITLE
Rename patmatch to mcase after its main macro

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ ERL_SRC_DIR = ${datadir}/distel/src
 ERL_SRC := $(wildcard src/*.erl)
 ERL_OBJ := $(patsubst src/%.erl,ebin/%.beam,${ERL_SRC})
 
-ELISP_SRC := elisp/erlext.el
+ELISP_SRC := elisp/erlext.el elisp/mcase.el elisp/net-fsm.el elisp/epmd.el
 ELISP_OBJ := $(patsubst %.el,%.elc,${ELISP_SRC})
 
 DOC_SRC  := doc/distel.texi
@@ -46,7 +46,7 @@ ebin/%.beam: src/%.erl
 
 ## Elisp
 elisp/%.elc: elisp/%.el
-	${emacs} -batch -f batch-byte-compile $<
+	${emacs} -batch -L elisp -f batch-byte-compile $<
 
 ## Info documentation
 doc/distel.info: ${DOC_SRC}

--- a/elisp/edb.el
+++ b/elisp/edb.el
@@ -313,7 +313,7 @@ Returns NIL if this cannot be ensured."
                 (ewoc-create 'edb-monitor-insert-process
                              (edb-monitor-header)))
           (mapc (lambda (item)
-                  (mlet [pid mfa status info] item
+                  (mcase-let [pid mfa status info] item
                     (ewoc-enter-last edb-processes
                                      (make-edb-process pid
                                                        mfa

--- a/elisp/erl-service.el
+++ b/elisp/erl-service.el
@@ -775,8 +775,7 @@ default.)"
   "Find the source code for MODULE in a buffer, loading it if necessary.
 When FUNCTION is specified, the point is moved to its start."
   ;; Add us to the history list
-  (ring-insert-at-beginning erl-find-history-ring
-                            (copy-marker (point-marker)))
+  (ring-insert-at-beginning erl-find-history-ring (point-marker))
   (if (equal module (erlang-get-module))
       (when function
         (erl-search-function function arity))
@@ -1099,7 +1098,7 @@ variables."
     (erl-display-message-or-view
      (with-temp-buffer
        (dolist (match matches)
-         (mlet [mod func arity doc] match
+         (mcase-let [mod func arity doc] match
            (let ((entry (format "%s:%s/%s" mod func arity)))
              (put-text-property 0 (length entry)
                                 'face 'erl-fdoc-name-face
@@ -1240,7 +1239,7 @@ The match positions are erl-mfa-regexp-{module,function,arity}-match.")
             (let ((inhibit-read-only t))
               (erase-buffer)
               (dolist (call calls)
-                (mlet [m f a line] call
+                (mcase-let [m f a line] call
                   (erl-propertize-insert (list 'module m
                                                'function f
                                                'arity a

--- a/elisp/erl.el
+++ b/elisp/erl.el
@@ -19,7 +19,7 @@
 (provide 'erl)                          ; avoid recursive require
 (require 'derl)
 (require 'erl-service)
-(require 'patmatch)
+(require 'mcase)
 
 ;; Process ID structure.
 ;;
@@ -299,7 +299,7 @@ The overall syntax for receive is:
        ...)
     . AFTER)
 
-The pattern syntax is the same as `pmatch'."
+The pattern syntax is the same as `mcase-let'."
   `(erl-start-receive (capture-bindings ,@vars)
                         ,(mcase-parse-clauses clauses)
                         (lambda () ,@after)))


### PR DESCRIPTION
Consistently use mcase as prefix for all functions.

In my tests all features are still working as expected.  `mcase-test` (was `pmatch-test`) still fails in one of its tests. I have traced to the initial commit of the project and it failed there as well. So this failure is left as is.
