### PR TITLE
Convert source file to UTF-8 in order to compile with Erlang R17

### DIFF
--- a/src/otp_doc.erl
+++ b/src/otp_doc.erl
@@ -311,7 +311,7 @@ fold_file_lines(FD,Fun,Acc) ->
 trim_nl(Str) -> lists:reverse(tl(lists:reverse(Str))).
 
 %% --------------------------------------------------------------------------
-%% Schönfinkelisation
+%% SchÃ¶nfinkelisation
 curry(F,Arg) ->
   case erlang:fun_info(F,arity) of
     %% {_,1} -> fun() -> F(Arg) end;


### PR DESCRIPTION
This commit replaces byte "f6" with bytes "c3 b6".

The snapshot of R17 pre-release used for compiling is 039ea3a.

The compilation succeeds also with R13B04 so hopefully this should not
introduce regressions for versions of Erlang older than R17.

See also http://erlang.org/doc/apps/stdlib/unicode_usage.html
