### PR TITLE
ping the node after choosing name to fix the lazy-connect strategy side ...

### DIFF
--- a/elisp/erl-service.el
+++ b/elisp/erl-service.el
@@ -63,7 +63,8 @@ Use \\[erl-choose-nodename] to set or change default node name."
       (error "No node name given"))
     (setq erl-nodename-cache name)
     (setq distel-modeline-node name-string)
-    (force-mode-line-update))
+    (force-mode-line-update)
+    (erl-ping name))
   erl-nodename-cache)
 
 ;;;;; Call MFA lookup


### PR DESCRIPTION
...effect like:

http://erlang.org/pipermail/erlang-questions/2009-September/046406.html

The erlang node connection strategy will lead to the firt-call-failure, for example, if you interpret one module at once after choosing a node name, the interpret flag will be set incorrectly, and then will not allow you to set breakpoint on a module. 

In a word, choosing a node name will not trigger to connect, but a rpc-call will. To solve the firt-call-failure, one can check the connection before the substantial call operation, or ping the node in advance, since the connection is not broken frequently. 

The role ping operation plays likes the load operation in the link，which have done the same to avoid the failure.  I quote because the author is me and five years later the problem is still unsolved, pity. 
