### PR TITLE
Make the code Emacs 25.0.50.1 compatible

### DIFF
--- a/elisp/edb.el
+++ b/elisp/edb.el
@@ -218,7 +218,7 @@ Available commands:
     (insert text)))
 
 (defun edb-monitor-format (pid mfa status info)
-  (labels ((cut (s w)
+  (cl-labels ((cut (s w)
                 (if (> (length s) w)
                     (substring s 0 w)
                   s))


### PR DESCRIPTION
Simply followed the deprecated warning shown by Emacs upon boot.