### PR TITLE
Add utf8 atom, Closes #61

### DIFF
--- a/elisp/derl.el
+++ b/elisp/derl.el
@@ -62,6 +62,7 @@ Used for sending exit signals when the node goes down.")
 (defconst derl-flag-hidden-atom-cache   #x40)
 (defconst derl-flag-new-fun-tags        #x80)
 (defconst derl-flag-extended-pids-ports #x100)
+(defconst derl-flag-utf8-atoms          #x10000)
 
 ;; ------------------------------------------------------------
 ;; External API
@@ -198,7 +199,8 @@ complete and we become live."
      (fsm-encode1 110)                  ; tag (n)
      (fsm-encode2 5)                    ; version
      (fsm-encode4 (logior derl-flag-extended-references
-                          derl-flag-extended-pids-ports))
+                          derl-flag-extended-pids-ports
+                          derl-flag-utf8-atoms))
      (fsm-insert (symbol-name erl-node-name)))))
 
 (defun derl-send-challenge-reply (challenge)

--- a/elisp/erlext.el
+++ b/elisp/erlext.el
@@ -47,7 +47,8 @@
     (smallInt   . 97)
     (int        . 98)
     (float      . 99)                   ;superseded by newFloat
-    (atom       . 100)
+    (atom       . 100)                  ;superseded by atom_utf8
+    (atom_utf8  . 118)
     (ref        . 101)                  ;superseded by newRef
     (port       . 102)
     (pid        . 103)
@@ -399,6 +400,7 @@
       ((newFloat)   (erlext-read-ieee-double))
       ((float)      (erlext-read-float))
       ((atom)       (erlext-read-atom))
+      ((atom_utf8)  (erlext-read-atom))
       ((smallTuple) (erlext-read-small-tuple))
       ((largeTuple) (erlext-read-large-tuple))
       ((list)       (erlext-read-list))

--- a/elisp/erlext.el
+++ b/elisp/erlext.el
@@ -49,6 +49,7 @@
     (float      . 99)                   ;superseded by newFloat
     (atom       . 100)                  ;superseded by atom_utf8
     (atom_utf8  . 118)
+    (smallAtom_utf8  . 119)
     (ref        . 101)                  ;superseded by newRef
     (port       . 102)
     (pid        . 103)
@@ -401,6 +402,7 @@
       ((float)      (erlext-read-float))
       ((atom)       (erlext-read-atom))
       ((atom_utf8)  (erlext-read-atom))
+      ((smallAtom_utf8)  (erlext-read-small-atom))
       ((smallTuple) (erlext-read-small-tuple))
       ((largeTuple) (erlext-read-large-tuple))
       ((list)       (erlext-read-list))
@@ -496,6 +498,9 @@
 
 (defun erlext-read-atom ()
   (let ((length (erlext-read2)))
+    (intern (erlext-readn length))))
+(defun erlext-read-small-atom ()
+  (let ((length (erlext-read1)))
     (intern (erlext-readn length))))
 (defun erlext-read-small-tuple ()
   (erlext-read-tuple (erlext-read1)))


### PR DESCRIPTION
## Summary
Fixes issue with OTP20 update where the derl node connection would be refused do to lack of UTF8_ATOMS support.

This pull request closes issue #61.

## Changes
### Changes to `derl.el`
When calling `derl-send-name`, added required flag (`derl-flag-utf8-atoms`) to indicate that derl can receive utf8 atoms and utf8 small atoms.

### Changes to `erlext.el`
Added `(atom_utf8 . 118)` and `(smallAtom_utf8 . 119)` to `erlext-tag-alist`. 

- `atom_utf8` uses the same parsing code as `atom`
- `smallAtom_utf8` takes 1 rather than 2 bytes when reading the length of the atom

## Limitations
Small atoms are parsed correctly, however all atoms are sent back to the node as regular atoms with 2 bytes dedicated to the length of the atom.