### PR TITLE
Rename edb.el to distel-debug.el to avoid conflict

### DIFF
--- a/elisp/distel-debug.el
+++ b/elisp/distel-debug.el
@@ -1,4 +1,4 @@
-;;; edb.el --- Erlang debugger front-end
+;;; distel-debug.el --- Erlang debugger front-end
 
 (eval-when-compile (require 'cl))
 (require 'erl)
@@ -866,4 +866,4 @@ breakpoints are already marked as stale."
   (loop for x in list
         when (funcall pred x) return x))
 
-(provide 'edb)
+(provide 'distel-debug)

--- a/elisp/distel.el
+++ b/elisp/distel.el
@@ -44,7 +44,7 @@
 
 (require 'erl)
 (require 'erl-service)
-(require 'edb)
+(require 'distel-debug)
 
 (require 'distel-ie)
 


### PR DESCRIPTION
An Emacs package named "edb" exists [1].  It would be best to also
change the symbol prefix used here, to avoid the conflict completely,
but this commit doesn't do that.

[1]: https://github.com/emacsorphanage/edb